### PR TITLE
Hotfix for gulp build lacking of baseUrl

### DIFF
--- a/config/rjs_config.json
+++ b/config/rjs_config.json
@@ -1,6 +1,7 @@
 {
   "name": "main",
   "out": "main.js",
+  "baseUrl": "./dist/frontend",
   "shim": {
     "videojs": "videojs",
     "bootstrap": {


### PR DESCRIPTION
```gulp``` & ```gulp build``` are passed locally.