### PR TITLE
Replace call to loadUrl with loadURL.

### DIFF
--- a/src/modules/backuper/DropboxBackuper.js
+++ b/src/modules/backuper/DropboxBackuper.js
@@ -76,7 +76,7 @@ class DropboxBackuper {
         title: 'Kaku',
         'node-integration': false
       });
-      authWindow.loadUrl(url);
+      authWindow.loadURL(url);
       authWindow.show();
       authWindow.on('close', () => {
         authWindow = null;


### PR DESCRIPTION
Fixed :bug: #472 

What got changed here :
- Replace single instance of call to ```loadUrl ``` with ```loadURL``` since ```loadUrl``` method has been removed in [electron v1.0](https://github.com/electron/electron/releases/tag/v1.0.0)