### PR TITLE
Update pouchDB dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/EragonJ/Kaku",
   "scripts": {
+    "preinstall": "npm config set abi=50",
     "dev": "./node_modules/.bin/webpack --watch",
     "start": "./node_modules/.bin/electron .",
     "compile:less": "./node_modules/.bin/lessc src/public/less/index.less src/public/css/index.css",
@@ -124,7 +125,7 @@
     "node-itunes-rss-data": "^1.1.1",
     "node-soundcloud": "0.0.5",
     "node-uuid": "^1.4.7",
-    "pouchdb": "^3.6.0",
+    "pouchdb": "^6.1.0",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-emoji": "^0.4.4",

--- a/src/modules/Database.js
+++ b/src/modules/Database.js
@@ -1,4 +1,5 @@
 import PouchDB from 'pouchdb';
+
 const KakuDB = new PouchDB('kaku');
 
 // Note:


### PR DESCRIPTION
See: [here](https://david-dm.org/EragonJ/kaku)
Because PouchDB 3.6.0 version have **Arbitrary Code Injection** secure problem, so I try fix this problem.

But I update dependcy to **6.1.0** version have this error _(about leveldown)_:
![](http://i.imgur.com/V9SVXAZ.png)

I go to PouchDB Github find related [issue](https://github.com/pouchdb/pouchdb/issues?utf8=%E2%9C%93&q=leveldown).

finally, I use **pouchdb-browser** fixed this error after test seems work perfect, please @EragonJ check it! Thanks.