### PR TITLE
Introduction of thanks job

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "./node_modules/mocha/bin/mocha -u tdd -t 5000 --reporter dot --compilers js:babel-core/register --require ./tests/unit/setup.js 'tests/unit/*.test.js'",
     "uitest-all": "npm run-script prepare-build && npm run-script uitest",
     "uitest": "./node_modules/mocha/bin/mocha -u tdd -t 15000 --reporter dot tests/ui/*.test.js",
-    "thanks": "./node_modules/kaku-thanks/thanks.py -o ./data/"
+    "thanks": "./node_modules/kaku-thanks/execute_me_first && ./node_modules/kaku-thanks/thanks.py -o ./data/"
   },
   "build": {
     "appId": "com.kaku.kaku-desktop",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "beforebuild": "./bin/before-build",
     "test": "./node_modules/mocha/bin/mocha -u tdd -t 5000 --reporter dot --compilers js:babel-core/register --require ./tests/unit/setup.js 'tests/unit/*.test.js'",
     "uitest-all": "npm run-script prepare-build && npm run-script uitest",
-    "uitest": "./node_modules/mocha/bin/mocha -u tdd -t 15000 --reporter dot tests/ui/*.test.js"
+    "uitest": "./node_modules/mocha/bin/mocha -u tdd -t 15000 --reporter dot tests/ui/*.test.js",
+    "thanks": "./node_modules/kaku-thanks/thanks.py -o ./data/"
   },
   "build": {
     "appId": "com.kaku.kaku-desktop",
@@ -123,6 +124,7 @@
     "font-awesome": "^4.4.0",
     "jquery": "^2.2.0",
     "kaku-core": "^0.0.14",
+    "kaku-thanks": "git://github.com/funilrys/kaku-thanks.git",
     "mdns-js": "^0.5.0",
     "node-itunes-rss-data": "^1.1.1",
     "node-soundcloud": "0.0.5",


### PR DESCRIPTION
Fixed bug: The lack of automation around the generation of thanks.json

What got changed here :
- `package.json`
  - Introduction of [kaku-thanks](https://github.com/funilrys/kaku-thanks)
  - Introduction of `npm run thanks` (Please execute `npm i` before)


# TODO BEFORE MERGING: 
- @EragonJ  or others
   - As I don't want to break the master branch can you guys generate/push the `package-lock.json` according to my changes? Indeed as my `node -v == v8.5.0` and `npm -v == 5.4.2`, I don't want to break the dependencies and others around master ...

## Note

It (`npm run thanks`) should work like a charm if you are a maintainer of the Transifex repository but if there's an issue after tests let me know :smile_cat: 