### PR TITLE
Adds add-to-queue option in Track's context menu

### DIFF
--- a/src/views/components/shared/track/track.js
+++ b/src/views/components/shared/track/track.js
@@ -73,12 +73,7 @@ class Track extends Component {
     if (TabManager.tabName !== 'play-queue') {
       let menuItemToAddToQueue = new MenuItem({
         label: 'Add to Queue',
-        click: () => {
-          Player.addTracks([track]);
-          if (!Player.playingTrack) {
-            Player.playNextTrack(Player.tracks.indexOf(track));
-          }
-        }
+        click: () => Player.addTracks([track])
       });
       menu.insert(++position, menuItemToAddToQueue);
     }

--- a/src/views/components/shared/track/track.js
+++ b/src/views/components/shared/track/track.js
@@ -68,6 +68,20 @@ class Track extends Component {
   _createContextMenu(track) {
     let menu = new Menu();
     let playlists = PlaylistManager.playlists;
+    let position = -1;
+
+    if (TabManager.tabName !== 'play-queue') {
+      let menuItemToAddToQueue = new MenuItem({
+        label: 'Add to Queue',
+        click: () => {
+          Player.addTracks([track]);
+          if (!Player.playingTrack) {
+            Player.playNextTrack(Player.tracks.indexOf(track));
+          }
+        }
+      });
+      menu.insert(++position, menuItemToAddToQueue);
+    }
 
     playlists.forEach((playlist) => {
       let clickToAddTrack = ((playlist) => {
@@ -107,7 +121,7 @@ class Track extends Component {
           menu.append(menuItemToRemoveTrack);
         }
         else {
-          menu.insert(0, menuItemToAddTrack);
+          menu.insert(++position, menuItemToAddTrack);
         }
       }
       else {
@@ -116,7 +130,7 @@ class Track extends Component {
         // but no matter how, right now we have internal protect in
         // playlist.addTrack() to make sure we won't add the same track
         // to the same playlist.
-        menu.insert(0, menuItemToAddTrack);
+        menu.insert(++position, menuItemToAddTrack);
       }
     });
     return menu;

--- a/src/views/modules/Player.js
+++ b/src/views/modules/Player.js
@@ -173,7 +173,12 @@ Player.prototype.addTracks = function(tracks, noUpdate) {
     return;
   }
 
-  this.tracks = [].concat(this.tracks, tracks);
+  tracks.forEach((track) => {
+    if (!this.tracks.includes(track)) {
+      this.tracks.push(track);
+    }
+  }, this);
+
   this.randomIndexes = this.makeRandomIndexes(this.tracks.length);
 
   if (!noUpdate) {

--- a/src/views/modules/Player.js
+++ b/src/views/modules/Player.js
@@ -174,7 +174,7 @@ Player.prototype.addTracks = function(tracks, noUpdate) {
   }
 
   tracks.forEach((track) => {
-    if (!this.tracks.includes(track)) {
+    if (!this.tracks.some(item => item.id === track.id)) {
       this.tracks.push(track);
     }
   }, this);


### PR DESCRIPTION
Fixed bug: #545 

What got changed here :
* Add check to prevent duplicate tracks from being added to the queue
* Add add-to-queue option in Track's context menu

